### PR TITLE
Feature/variables in translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 A small package for implementing translations in [Vue.js](http://vuejs.org/). Instead of using a dot based key to fetch a translated string, it just uses the default string itself as the key.
 
-In short `{{ $t('Hello world') }}` instead of `{{ $t('messages.hello_world') }}`. Better yet: `{{ 'Hello world' | translate }}`
+In short `{{ $t('Hello world') }}` instead of `{{ $t('messages.hello_world') }}`.
+
+Better yet: `{{ 'Hello world' | translate }}`
 
 There are trade-offs to doing it this way:
 
@@ -14,7 +16,7 @@ Pros:
 Cons:
 - Large strings are unwieldy
 - Small changes (like capitalization) are not recognized
-- Changing strings in the default locale will require updates in all language files (necessary anyway, as the copy has changed)
+- Changing strings in the default locale will require updates in all language files (technically necessary anyway, as the copy has changed)
 
 ## Installation
 
@@ -41,7 +43,7 @@ Vue.use(i18n, translations)
 
 ## Usage
 
-Set a default locale in the root data of your application.
+Set a default locale in the __root__ data of your application.
 
 ```javascript
 <template>
@@ -114,7 +116,7 @@ __Do this__
 
 ## Inline HTML
 
-It's often the case that your sentences will not form nice little compartmentalized strings like `Hello world`. Often you'll get HTML spliced in the middle. Fragmented, messy, and possibly not even accurate given the way some foreign languages are structured.
+It's often the case that your sentences will not form nice little compartmentalized strings like `Hello world`. Often you'll get HTML spliced in the middle.
 
 __Don't__ do this
 ```html
@@ -131,8 +133,8 @@ __Don't__ do this
 
 __Do this__
 ```html
-<div v-trans="$root.locale" key="Please perform |this action| to complete the thing">
-    <span>Please perform</span><a href="#" @click.prevent="action')">this action</a><span>to complete the thing</span>
+<div v-locale="$root.locale" key="Please perform |this action| to complete the thing">
+    <span></span><a href="#" @click.prevent="action')"></a><span></span>
 </div>
 ```
 ```javascript
@@ -141,12 +143,10 @@ __Do this__
 },
 ```
 
-> Note: The `span` tags above matter. Each segment of text should have its own compartmentalized element
-
 ## All Together Now!
 ```html
-<div v-trans="$root.locale" key="Thanks for signing up! Confirm |{email} is correct| to continue to the site." :replace="{ email: email }">
-    <span>Thanks for signing up! Confirm </span><a href="#" @click="confirm">{email} is correct</a><span> to continue to the site.</span>
+<div v-locale="$root.locale" key="Thanks for signing up! Confirm |{email} is correct| to continue to the site." :replace="{ email: email }">
+    <span></span><a href="#" @click="confirm"></a><span></span>
 </div>
 ```
 

--- a/package.json
+++ b/package.json
@@ -28,10 +28,8 @@
       "babelify"
     ]
   },
-  "dependencies": {
-    "vue": "^1.0.24"
-  },
   "devDependencies": {
+    "vue": "^1.0.24",
     "babel-core": "^6.0.0",
     "babel-plugin-transform-runtime": "^6.0.0",
     "babel-preset-es2015": "^6.0.0",

--- a/src/main.js
+++ b/src/main.js
@@ -13,72 +13,55 @@ module.exports = {
       return replaced;
     }
 
-    Vue.directive('trans', {
+    Vue.directive('locale', {
       params: ['key', 'replace'],
 
       update: function (locale) {
-        // reset content
-        let original = this.vm.$t(this.params.key, { locale: 'default' });
-
-        let original_substrings = original.split('|');
-
-        let children = this.el.children;
-
-        for (let i = 0; i < children.length; i++) {
-          children[i].innerText = original_substrings[i];
-        }
-
-        // do translation
         let translation = this.vm.$t(this.params.key, this.params.replace || {});
 
         let initial_substrings = this.params.key.split('|');
         let translated_substrings = translation.split('|');
 
-        children = this.el.children;
+        let children = this.el.children;
 
         for (let i = 0; i < children.length; i++) {
-          let index = initial_substrings.indexOf(children[i].innerText);
+          if (! translated_substrings[i]) { continue }
 
-          if (index > -1) {
-            children[i].innerText = translated_substrings[index];
-          }
+          children[i].innerText = translated_substrings[i];
         }
       }
     });
 
-
-
     Vue.prototype.$t = function (key, vars) {
       var currentLocale = (vars && vars['locale']) ? vars['locale'] : this.$root.locale
-        var translations = Vue.locale_translations[currentLocale]
+      var translations = Vue.locale_translations[currentLocale]
 
-        if (translations) {
-          if (key in translations) {
+      if (translations) {
+        if (key in translations) {
+          return Vue.replace_vars(translations[key], vars);
+        }
+
+        // Also fall back to a sublocale, e.g. "fr" translations from the locale "fr_CA"
+        if (currentLocale && (currentLocale.indexOf('_') > -1)) {
+          var sublocale = currentLocale.slice(0, 2)
+
+          translations = locale_translations[sublocale]
+
+          if (translations && (key in translations)) {
             return Vue.replace_vars(translations[key], vars);
-          }
-
-          // Also fall back to a sublocale, e.g. "fr" translations from the locale "fr_CA"
-          if (currentLocale && (currentLocale.indexOf('_') > -1)) {
-            var sublocale = currentLocale.slice(0, 2)
-
-            translations = locale_translations[sublocale]
-
-            if (translations && (key in translations)) {
-              return Vue.replace_vars(translations[key], vars);
-            }
-          }
-
-          if (window.console) {
-            console.warn(`Translations exist for the locale ${currentLocale}, but there is not an entry for '${key}'`)
           }
         }
 
-        return Vue.replace_vars(key, vars)
+        if (window.console) {
+          console.warn(`Translations exist for the locale ${currentLocale}, but there is not an entry for '${key}'`)
+        }
       }
 
-      Vue.filter('translate', function (key, vars) {
-        return this.$t(key, vars)
-      })
+      return Vue.replace_vars(key, vars)
     }
-  }
 
+    Vue.filter('translate', function (key, vars) {
+      return this.$t(key, vars)
+    })
+  }
+}

--- a/test/unit/main.spec.js
+++ b/test/unit/main.spec.js
@@ -74,7 +74,7 @@ describe('main.js', () => {
 
   it('will use the v-trans directive to translate an HTML element\'s children', () => {
     let vm = new Vue({
-      template: '<div v-trans="$root.locale" key="Thanks for signing up! Confirm |{email} is correct| to continue to the site" :replace="{ email: email }"><span id="part1">Please perform </span><a id="part2" href="#">this {value} action</a><span id="part3"> to complete the thing</span></div>',
+      template: '<div v-locale="$root.locale" key="Thanks for signing up! Confirm |{email} is correct| to continue to the site" :replace="{ email: email }"><b id="part1"></b><a id="part2" href="#"></a><span id="part3"></span></div>',
       data: function () {
         return {
           email: 'asdf@example.com',
@@ -83,10 +83,6 @@ describe('main.js', () => {
       }
     }).$mount()
 
-    /*expect(vm.$el.querySelector('#part1').textContent).toBe('Thanks for signing up! Confirm ')
-    expect(vm.$el.querySelector('#part2').textContent).toBe('asdf@example.com is correct')
-    expect(vm.$el.querySelector('#part3').textContent).toBe(' to continue to the site')*/
-
     expect(vm.$el.querySelector('#part1').textContent).toBe('Gracias por registrarte! Confirmar ')
     expect(vm.$el.querySelector('#part2').textContent).toBe('asdf@example.com es correcta')
     expect(vm.$el.querySelector('#part3').textContent).toBe(' para continuar al sitio')
@@ -94,7 +90,7 @@ describe('main.js', () => {
 
   it('will use the v-trans directive to translate an HTML element\'s children2', () => {
     let vm = new Vue({
-      template: '<div v-trans="$root.locale" key="Thanks for signing up! Confirm |{email} is correct| to continue to the site" :replace="{ email: email }"><span id="part1">Please perform </span><a id="part2" href="#">this {value} action</a><span id="part3"> to complete the thing</span></div>',
+      template: '<div v-locale="$root.locale" key="Thanks for signing up! Confirm |{email} is correct| to continue to the site" :replace="{ email: email }"><b id="part1"></b><a id="part2" href="#"></a><span id="part3"></span></div>',
       data: function () {
         return {
           email: 'asdf@example.com',

--- a/test/unit/main.spec.js
+++ b/test/unit/main.spec.js
@@ -4,18 +4,17 @@ import Main from '../../src/main'
 Vue.use(Main, {
   'es': {
     'Hello': 'Hola',
-    'Goodbye': 'Adiós'
+    'Goodbye': 'Adiós',
+    'You have used {count} out of {limit}': 'Ha utilizado {count} de los {limit}',
+    'Thanks for signing up! Confirm |{email} is correct| to continue to the site': 'Gracias por registrarte! Confirmar |{email} es correcta| para continuar al sitio'
   },
   'fr': {
     'Hello': 'Bonjour',
-    'Goodbye': 'Au Revoir'
+    'Goodbye': 'Au Revoir',
+    'You have used {count} out of {limit}': 'Vous avez utilisé {count} sur {limit}'
   },
   'fr_CA': {
     'Hello': 'Bonjour, du Canada'
-  },
-  'pirate': {
-    'Hello': 'Ahoy',
-    'Goodbye': 'Godspeed'
   }
 })
 
@@ -40,10 +39,6 @@ describe('main.js', () => {
     vm.$root.locale = 'fr'
     expect(vm.$t('Hello')).toBe('Bonjour')
     expect(vm.$t('Goodbye')).toBe('Au Revoir')
-
-    vm.$root.locale = 'pirate'
-    expect(vm.$t('Hello')).toBe('Ahoy')
-    expect(vm.$t('Goodbye')).toBe('Godspeed')
   })
 
   it('will use the dialect translations, and fall back to base translations when not specified', () => {
@@ -52,6 +47,65 @@ describe('main.js', () => {
     vm.$root.locale = 'fr_CA'
     expect(vm.$t('Hello')).toBe('Bonjour, du Canada')
     expect(vm.$t('Goodbye')).toBe('Au Revoir')
+  })
+
+  it('will replace vars supplied as a second param', () => {
+    let vm = new Vue
+
+    let count = 10, limit = 100
+
+    expect(vm.$t('You have used {count} out of {limit}')).toBe('You have used {count} out of {limit}')
+
+    expect(vm.$t('You have used {count} out of {limit}', {count, limit})).toBe('You have used 10 out of 100')
+
+    vm.$root.locale = 'es'
+    expect(vm.$t('You have used {count} out of {limit}')).toBe('Ha utilizado {count} de los {limit}')
+    expect(vm.$t('You have used {count} out of {limit}', {count, limit})).toBe('Ha utilizado 10 de los 100')
+
+    vm.$root.locale = 'fr'
+    expect(vm.$t('You have used {count} out of {limit}')).toBe('Vous avez utilisé {count} sur {limit}')
+    expect(vm.$t('You have used {count} out of {limit}', {count, limit})).toBe('Vous avez utilisé 10 sur 100')
+
+    vm.$root.locale = 'fr_CA'
+    expect(vm.$t('You have used {count} out of {limit}')).toBe('Vous avez utilisé {count} sur {limit}')
+    expect(vm.$t('You have used {count} out of {limit}', {count, limit})).toBe('Vous avez utilisé 10 sur 100')
+  })
+
+
+  it('will use the v-trans directive to translate an HTML element\'s children', () => {
+    let vm = new Vue({
+      template: '<div v-trans="$root.locale" key="Thanks for signing up! Confirm |{email} is correct| to continue to the site" :replace="{ email: email }"><span id="part1">Please perform </span><a id="part2" href="#">this {value} action</a><span id="part3"> to complete the thing</span></div>',
+      data: function () {
+        return {
+          email: 'asdf@example.com',
+          locale: 'es'
+        }
+      }
+    }).$mount()
+
+    /*expect(vm.$el.querySelector('#part1').textContent).toBe('Thanks for signing up! Confirm ')
+    expect(vm.$el.querySelector('#part2').textContent).toBe('asdf@example.com is correct')
+    expect(vm.$el.querySelector('#part3').textContent).toBe(' to continue to the site')*/
+
+    expect(vm.$el.querySelector('#part1').textContent).toBe('Gracias por registrarte! Confirmar ')
+    expect(vm.$el.querySelector('#part2').textContent).toBe('asdf@example.com es correcta')
+    expect(vm.$el.querySelector('#part3').textContent).toBe(' para continuar al sitio')
+  })
+
+  it('will use the v-trans directive to translate an HTML element\'s children2', () => {
+    let vm = new Vue({
+      template: '<div v-trans="$root.locale" key="Thanks for signing up! Confirm |{email} is correct| to continue to the site" :replace="{ email: email }"><span id="part1">Please perform </span><a id="part2" href="#">this {value} action</a><span id="part3"> to complete the thing</span></div>',
+      data: function () {
+        return {
+          email: 'asdf@example.com',
+          locale: 'en'
+        }
+      }
+    }).$mount()
+
+    expect(vm.$el.querySelector('#part1').textContent).toBe('Thanks for signing up! Confirm ')
+    expect(vm.$el.querySelector('#part2').textContent).toBe('asdf@example.com is correct')
+    expect(vm.$el.querySelector('#part3').textContent).toBe(' to continue to the site')
   })
 
 })


### PR DESCRIPTION
Adds variable replacement syntax. Adds "locale" directive to keep translations from getting fragmented.
